### PR TITLE
Fix an issue in DomDocumentFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2024-02-21
+### Fixed
+- An issue that occurred when the HTML contains something that looks like a charset definition within a `<script>` block.
+
 ## [0.1.0] - 2024-01-26
 ### Added
 - `Html2Text` class that converts HTML to formatted plain text.

--- a/tests/DomDocumentFactoryTest.php
+++ b/tests/DomDocumentFactoryTest.php
@@ -24,3 +24,25 @@ it('creates a DOMDocument object from an HTML string', function () {
         ->and($document->getElementById('page')?->textContent)
         ->toContain('Hello World!' . PHP_EOL . 'Lorem ipsum');
 });
+
+it(
+    'correctly parses documents containing something that can be interpreted as a charset definition within a ' .
+    'script block',
+    function () {
+        $html = <<<HTML
+<body>
+    <div>bla bla bla asdf test foo</div>
+
+    <script>
+        var someVar = ['foo', 'bar'];
+        var someObject = {};
+        someObject.charset = someVar[1];
+    </script>
+</body>
+HTML;
+
+        $document = DomDocumentFactory::make($html);
+
+        expect($document)->toBeInstanceOf(DOMDocument::class);
+    }
+);


### PR DESCRIPTION
Fix an issue hat occurred when the HTML contains something that looks like a charset definition within a `<script>` block.

Actually, the original code in the symfony DOMCrawler component, that this was copied from (https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/DomCrawler/Crawler.php#L1090C1-L1104C10) does swallow the exception, but I changed it because I thought it seems odd.